### PR TITLE
Days Lapsed property on Job

### DIFF
--- a/client/oil/src/components/Jobs/JobDetail.js
+++ b/client/oil/src/components/Jobs/JobDetail.js
@@ -76,10 +76,18 @@ export const JobDetail = props => {
     const [job, setJob] = useState({})
     const history = useHistory()
     const [modalOpen, setModalOpen] = useState(false)
+    const [lastCompletedDate, setLastCompletedDate] = useState("")
 
     useEffect(() => {
         getJobById(parseInt(jobId))
-            .then(setJob)
+            .then(job => {
+                setJob(job)
+                let dbDate = new Date(job.last_completed)
+                // correct the date, which will be off by one thanks to JS Date
+                dbDate.setDate(dbDate.getDate() + 1)
+                const niceDate = dbDate.toLocaleDateString('en-es')
+                setLastCompletedDate(niceDate)
+            })
     }, [])
 
     const handleModalOpen = () => {
@@ -104,7 +112,7 @@ export const JobDetail = props => {
                 <Typography className={classes.description} component="p" variant="p" align='left'>{job.description}</Typography>
                 <Typography className={classes.details} component="p" variant="p" align='left'>Repeats every {job.frequency} days</Typography>
                 <Typography className={classes.details} component="p" variant="p" align='left'>
-                    Last completed on {new Date(job.last_completed).toLocaleDateString('en-es')} by {job.last_completed_by?.first_name}
+                    Last completed on {lastCompletedDate} by {job.last_completed_by?.first_name}
                 </Typography>
 
                 {/* Only list out the shared user section if more than one user is on jobs.users */}

--- a/client/oil/src/components/Jobs/JobsList.js
+++ b/client/oil/src/components/Jobs/JobsList.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles(theme => ({
             margin: theme.spacing(1),
             height: "fit-content",
         },
+        marginBottom: "7vh"
     },
     fabs: {
         margin: theme.spacing(1),

--- a/server/oil/oilapi/models/job.py
+++ b/server/oil/oilapi/models/job.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+from datetime import date
 
 class Job(models.Model):
     title = models.CharField(max_length=50)
@@ -11,3 +12,11 @@ class Job(models.Model):
     last_completed = models.DateField(auto_now=False, auto_now_add=False)
     last_completed_by = models.ForeignKey(User, on_delete=models.DO_NOTHING, related_name="last_job_completer", null=True)
     users = models.ManyToManyField(User, related_name="job")
+
+    @property
+    def days_lapsed(self):
+        """How many days have passed since last completion"""
+        lapse = date.today() - self.last_completed
+        lapse_in_days = lapse.days
+        days_since_due = lapse_in_days - self.frequency
+        return days_since_due

--- a/server/oil/oilapi/views/job.py
+++ b/server/oil/oilapi/views/job.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from oilapi.models import Job, JobType, JobInvite, UserPair
-from datetime import date
+from datetime import date, datetime
 from django.db.models import Q
 from django.contrib.auth.models import User
 
@@ -22,9 +22,8 @@ class JobSerializer(serializers.ModelSerializer):
     class Meta:
         model = Job
         fields = ['id', 'title', 'description', 'type', 'frequency', 'created_at',
-                  'last_completed', 'last_completed_by', 'users']
+                  'last_completed', 'last_completed_by', 'users', 'days_lapsed']
         depth = 2
-
 
 class ShortJobSerializer(serializers.ModelSerializer):
     """JSON serializer for Jobs, abbreviated"""
@@ -54,7 +53,7 @@ class JobView(ViewSet):
         job.title = req['title']
         job.created_by = user
         job.frequency = req['frequency']
-        job.last_completed = req['last_completed']
+        job.last_completed = datetime.strptime(req['last_completed'], '%Y-%m-%d').date()
         job.description = req['description']
         job.last_completed_by = user
 


### PR DESCRIPTION
# Job Days Lapsed
## Description

- a Job object now includes a property called "days_lapsed" which represents days past since last completion minus frequency
- Therefore, when a job is due to be completed again, "days_lapsed" will be 0
- If a job is overdue by 1 days, "days_lapsed" will be 1, etc

Closes #50 

### Type
- [ ] Bug squish
- [x] New Feature
- [ ] Documentation