### PR TITLE
moved the history.push to a .then() after a job has been created/edited

### DIFF
--- a/client/oil/src/components/Jobs/JobForm.js
+++ b/client/oil/src/components/Jobs/JobForm.js
@@ -79,10 +79,15 @@ export const JobForm = props => {
         e.preventDefault()
         if (jobId) {
             editJob(formJob)
+                .then(() => {
+                    history.push("/jobs")
+                })
         } else {
             createJob(formJob)
+                .then(() => {
+                    history.push("/jobs")
+                })
         }
-        history.push("/jobs")
     }
 
     return (

--- a/client/oil/src/components/Jobs/JobsProvider.js
+++ b/client/oil/src/components/Jobs/JobsProvider.js
@@ -42,7 +42,6 @@ export const JobsProvider = props => {
             headers: apiHeaders(),
             body: JSON.stringify(newJob)
         })
-            .then(res => res.json())
     }
 
     const deleteJob = id => {

--- a/server/oil/.vscode/settings.json
+++ b/server/oil/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.pythonPath": "/Users/alexmartin/.local/share/virtualenvs/server-5CqkKvgF/bin/python",
+    "python.pythonPath": "/Users/alexmartin/.local/share/virtualenvs/server-BGwYABJz/bin/python",
     "sqltools.connections": [
         {
             "previewLimit": 50,


### PR DESCRIPTION
# First Job Appears
## Description

- fixes a bug in which the "/jobs" view rendered too fast to catch a new job after creating the first job
- tucked the "/jobs" route into a `.then()` after creating/editing the new job
- 
Closes #76 

### Type
- [x] Bug squish
- [ ] New Feature
- [ ] Documentation