### PR TITLE
Moved header and footer to Application Views to share PeopleContext

### DIFF
--- a/client/oil/src/components/ApplicationViews.js
+++ b/client/oil/src/components/ApplicationViews.js
@@ -10,12 +10,17 @@ import { PeopleProvider } from './People/PeopleProvider'
 import { PeopleSearch } from './People/PeopleSearch'
 import { PeopleList } from './People/PeopleList'
 import { Register } from './auth/Register'
+import { Header } from './Header/Header'
+import { Footer } from './Footer/Footer'
 
-export const ApplicationViews = () => {
+export const ApplicationViews = props => {
     return (
         <>
             <JobsProvider>
                 <PeopleProvider>
+
+                    <Header />
+
                     <Route exact path="/">
                         <Today />
                     </Route>
@@ -41,10 +46,13 @@ export const ApplicationViews = () => {
                         <PeopleList />
                     </Route>
 
+                    {/*Edit Profile*/}
                     <Route exact path="/profile">
-                        {/* <p>Edit Profile</p> */}
                         <Register />
                     </Route>
+
+                    <Footer theme={props.theme} />
+
                 </PeopleProvider>
             </JobsProvider>
         </>

--- a/client/oil/src/components/Oil.js
+++ b/client/oil/src/components/Oil.js
@@ -4,21 +4,15 @@ import { ApplicationViews } from './ApplicationViews'
 import { userTokenStorageKey } from './auth/authSettings'
 import { Login } from './auth/Login'
 import { Register } from './auth/Register'
-import { Footer } from './Footer/Footer'
-import { Header } from './Header/Header'
-import { PeopleProvider } from './People/PeopleProvider'
 
 export const Oil = ({ theme }) => {
     return (
         <>
-            <PeopleProvider>
                 <Route render={() => {
                     if (sessionStorage.getItem(userTokenStorageKey)) {
                         return (
                             <>
-                                <Header />
                                 <ApplicationViews />
-                                <Footer theme={theme} />
                             </>
                         )
                     } else {
@@ -33,7 +27,6 @@ export const Oil = ({ theme }) => {
                 <Route path="/register">
                     <Register />
                 </Route>
-            </PeopleProvider>
         </>
     )
 }


### PR DESCRIPTION
# Footer Name Change
## Description

- Previously, when a user changed their name in the profile edit form, the new name was not reflected in the footer
- By moving the `<Footer />` component inside of `<ApplicationViews />`, there is now only one PeopleContext, so the `currentUser` state is universal

Closes #78 

### Type
- [x] Bug squish
- [ ] New Feature
- [ ] Documentation