### PR TITLE
Inviter name on shared job invite

### DIFF
--- a/client/oil/src/components/Jobs/JobsList.js
+++ b/client/oil/src/components/Jobs/JobsList.js
@@ -171,7 +171,7 @@ export const JobsList = props => {
                                     if (i == invitedTo.length - 1) thisClass += ` ${classes.bottomItem}`
                                     return (
                                         <ListItem key={jobInvite.id} className={thisClass}>
-                                            <ListItemText primary={jobInvite.job.title} />
+                                            <ListItemText primary={`${jobInvite.job.title} (from ${jobInvite.inviter.first_name} ${jobInvite.inviter.last_name})`} />
                                             <ListItemIcon onClick={confirmReject} id={"request--" + jobInvite.id}>
                                                 <Fab className={`${classes.fabs} ${classes.reject}`} id={jobInvite.id} aria-label="reject">
                                                     <ClearIcon />


### PR DESCRIPTION
# Inviter Names
## Description

- Users can now see who invited them to jobs on the `/jobs` view


### Type
- [ ] Bug squish
- [x] New Feature
- [ ] Documentation